### PR TITLE
Change to not unescape the entire response

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 object Versions {
-    const val Ktor = "1.5.4"
+    const val Ktor = "1.6.0"
     const val JsonKt = "6.1.1"
     const val KotlinxSerializationJson = "1.2.1"
     const val uuid = "0.3.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/commonMain/kotlin/blue/starry/penicillin/core/request/action/Action.kt
+++ b/src/commonMain/kotlin/blue/starry/penicillin/core/request/action/Action.kt
@@ -93,7 +93,7 @@ internal fun checkError(request: HttpRequest, response: HttpResponse, content: S
             is JsonObject -> {
                 val code by error.byNullableInt
                 val message by error.byNullableString
-                
+
                 throwApiError(code, message.orEmpty(), content!!, request, response)
             }
             is JsonPrimitive -> {
@@ -109,13 +109,9 @@ internal fun checkError(request: HttpRequest, response: HttpResponse, content: S
 }
 
 internal suspend inline fun HttpResponse.readTextOrNull(): String? {
-    return runCatching { 
-        readText().unescapeHTML()
+    return runCatching {
+        readText()
     }.onFailure {
-        apiActionLogger.debug(it) { "Could not readText." }
+        apiActionLogger.debug(it) { "Failed to read text." }
     }.getOrNull()
-}
-
-internal fun String.unescapeHTML(): String {
-    return replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">")
 }

--- a/src/commonMain/kotlin/blue/starry/penicillin/core/request/action/StreamApiAction.kt
+++ b/src/commonMain/kotlin/blue/starry/penicillin/core/request/action/StreamApiAction.kt
@@ -79,26 +79,25 @@ public class StreamApiAction<L: StreamListener, H: StreamHandler<L>>(
 
             while (!channel.isClosedForRead) {
                 val line = channel.readUTF8Line() ?: continue
-                val content = line.unescapeHTML()
 
                 when {
-                    content.startsWith('{') -> {
-                        handler.handle(content.toJsonObject())
+                    line.startsWith('{') -> {
+                        handler.handle(line.toJsonObject())
                     }
-                    content.isBlank() -> {
+                    line.isBlank() -> {
                         listener.onHeartbeat()
                     }
                     else -> {
-                        val length = content.toIntOrNull()
+                        val length = line.toIntOrNull()
                         if (length != null) {
                             listener.onLength(length)
                         } else {
-                            listener.onUnknownData(content)
+                            listener.onUnknownData(line)
                         }
                     }
                 }
 
-                listener.onRawData(content)
+                listener.onRawData(line)
             }
 
             listener.onDisconnect(null)

--- a/src/commonMain/kotlin/blue/starry/penicillin/extensions/models/StatusText.kt
+++ b/src/commonMain/kotlin/blue/starry/penicillin/extensions/models/StatusText.kt
@@ -37,11 +37,11 @@ public val Status.text: String
         if (retweetedStatus?.extendedTweet != null) {
             "RT @${retweetedStatus!!.user.screenName}: ${retweetedStatus!!.text}"
         } else {
-            fullTextRaw ?: textRaw ?: throw IllegalStateException("Unsupported status format: $json")
+            fullTextRaw ?: textRaw ?: error("Unsupported status format: $json")
         }
     } else {
-        extendedTweet?.fullText ?: fullTextRaw ?: textRaw ?: throw IllegalStateException("Unsupported status format: $json")
-    }
+        extendedTweet?.fullText ?: fullTextRaw ?: textRaw ?: error("Unsupported status format: $json")
+    }.unescapeHTML()
 
 /**
  * Returns full-body status text which shortened urls in are each expanded.
@@ -80,3 +80,9 @@ public val Status.expandedTextWithIndices: String
             }
         }
     }
+
+private fun String.unescapeHTML(): String {
+    return replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+}

--- a/src/commonMain/kotlin/blue/starry/penicillin/extensions/models/StatusText.kt
+++ b/src/commonMain/kotlin/blue/starry/penicillin/extensions/models/StatusText.kt
@@ -29,7 +29,7 @@ package blue.starry.penicillin.extensions.models
 import blue.starry.penicillin.models.Status
 
 /**
- * Returns full-body status text.
+ * Returns full-body, unescaped status text.
  * Supports both tweet modes (Extend and Compat).
  */
 public val Status.text: String

--- a/src/jsMain/kotlin/blue/starry/penicillin/extensions/runBlocking.kt
+++ b/src/jsMain/kotlin/blue/starry/penicillin/extensions/runBlocking.kt
@@ -25,6 +25,7 @@
 package blue.starry.penicillin.extensions
 
 import blue.starry.penicillin.core.experimental.PenicillinExperimentalApi
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.promise
 import mu.KLogger
@@ -34,6 +35,7 @@ import kotlin.coroutines.CoroutineContext
 @PublishedApi
 internal val promiseLogger: KLogger = KotlinLogging.logger("Penicillin.PromiseLogger")
 
+@OptIn(DelicateCoroutinesApi::class)
 @PenicillinExperimentalApi
 internal actual fun <T> runBlockingAlt(
     context: CoroutineContext,

--- a/src/jvmTest/kotlin/tests/Utilities.kt
+++ b/src/jvmTest/kotlin/tests/Utilities.kt
@@ -26,6 +26,7 @@
 
 package tests
 
+import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import mu.KotlinLogging
@@ -49,6 +50,7 @@ internal inline fun <T> measurePerformance(label: String, block: () -> T): T {
     return result as T
 }
 
+@OptIn(DelicateCoroutinesApi::class)
 internal inline fun measurePerformanceAsync(label: String, crossinline block: () -> Unit) {
     if (!logger.isTraceEnabled) {
         block()


### PR DESCRIPTION
Fixed a bug in which the entire response body was unescaped, causing the start index of StatusEntity to be misaligned.

From now on, `Status#text` will return an unescaped string with HTML reference characters as before, and `Status#textRaw`, `Status#fullTextRaw`, etc. will return an unescaped string.

Ref. https://github.com/StarryBlueSky/Penicillin/issues/36 